### PR TITLE
tooltip の表示がリストの選択の邪魔にならないように表示場所を右側に変更

### DIFF
--- a/src/components/FileListViewer/FileListViewer.tsx
+++ b/src/components/FileListViewer/FileListViewer.tsx
@@ -51,7 +51,7 @@ const ItemRow = memo(function ItemRow({
     style: CSSProperties | undefined
 }) {
     return (
-        <Tooltip title={entry.name} placement="bottom-start">
+        <Tooltip title={entry.name} placement="right-start">
             <ListItem style={style} key={index} component="div" disablePadding dense>
                 <ListItemButton
                     selected={selected}

--- a/src/components/ImageEntriesViewer/ImageEntriesViewer.tsx
+++ b/src/components/ImageEntriesViewer/ImageEntriesViewer.tsx
@@ -24,7 +24,7 @@ const ItemRow = memo(function ItemRow({
     style: CSSProperties | undefined
 }) {
     return (
-        <Tooltip title={entry} placement="bottom-start">
+        <Tooltip title={entry} placement="right-start">
             <ListItem style={style} key={index} component="div" disablePadding dense>
                 <ListItemButton
                     selected={selected}


### PR DESCRIPTION
 tooltip の表示がリストの選択の邪魔にならないように表示場所を右側に変更