### PR TITLE
最初のページを1ページ表示する機能を追加

### DIFF
--- a/src/components/Settings/PageSettings/Items/FirstPageSetting.tsx
+++ b/src/components/Settings/PageSettings/Items/FirstPageSetting.tsx
@@ -1,0 +1,44 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Typography, Box, Switch } from "@mui/material";
+import { emit } from "@tauri-apps/api/event";
+import { settingsStore } from "../../../../settings/SettingsStore";
+import { useAppDispatch, useSelector } from "../../../../Store";
+import { setIsFirstPageSingleView } from "../../../../reducers/ViewReducer";
+import { debug } from "@tauri-apps/plugin-log";
+
+
+/**
+ * First page setting component.
+ */
+export default function FirstPageSetting() {
+    const { t } = useTranslation();
+    const { isFirstPageSingleView } = useSelector(state => state.view);
+    const dispatch = useAppDispatch();
+
+    const handleFirstPageSingleViewSwitchChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+        debug(`First page single view switch changed to ${e.target.checked}`);
+        dispatch(setIsFirstPageSingleView(e.target.checked));
+        await settingsStore.set("first-page-single-view", e.target.checked);
+
+        // The Store state is isolated within each WebView context and is not reflected in the main window's Store.
+        // Notify the main window to apply the changes.
+        await emit("view-settings-changed", {
+            key: "isFirstPageSingleView",
+            value: e.target.checked
+        });
+    }, [dispatch]);
+
+    debug(`First page single view: ${isFirstPageSingleView}`)
+    return (
+        <Box display="flex">
+            <Typography alignContent="center" sx={{ paddingRight: "12px" }}>
+                {t('settings.page.first-page.title')}
+            </Typography>
+            <Switch
+                checked={isFirstPageSingleView}
+                onChange={handleFirstPageSingleViewSwitchChange}
+            />
+        </Box>
+    );
+}

--- a/src/components/Settings/PageSettings/PageSettings.tsx
+++ b/src/components/Settings/PageSettings/PageSettings.tsx
@@ -1,0 +1,17 @@
+import { useTranslation } from "react-i18next";
+import { Typography, Box } from "@mui/material";
+import FirstPageSetting from "./Items/FirstPageSetting";
+
+/**
+ * Page settings component.
+ */
+export default function PageSettings() {
+    const { t } = useTranslation();
+
+    return (
+        <Box>
+            <Typography variant="h5">{t('settings.page.title')}</Typography>
+            <FirstPageSetting />
+        </Box>
+    );
+}

--- a/src/components/Settings/SettingsView.tsx
+++ b/src/components/Settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { JSX } from 'react';
 import { useTranslation } from "react-i18next";
 import { Tab, Tabs, Box } from '@mui/material';
 import GeneralSettings from './GeneralSettings/GeneralSettings';
@@ -7,6 +7,7 @@ import RenderingSettings from './RenderingSettings/RenderingSettings';
 import TabPanel from '../TabPanel/TabPanel';
 import AboutPage from './AboutPage/AboutPage';
 import FileNavigatorSettings from './FileNavigatorSettings/FileNavigatorSettings';
+import PageSettings from './PageSettings/PageSettings';
 
 /**
  * Settings page component.
@@ -18,6 +19,15 @@ export default function SettingsView() {
     const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
         setValue(newValue);
     };
+
+    const tabs: { label: string, panel: JSX.Element }[] = [
+        { label: t('settings.general.tab-name'), panel: <GeneralSettings /> },
+        { label: t('settings.page.tab-name'), panel: <PageSettings /> },
+        { label: t('settings.rendering.tab-name'), panel: <RenderingSettings /> },
+        { label: t('settings.developer.tab-name'), panel: <DeveloperSettings /> },
+        { label: t('settings.file-navigator.tab-name'), panel: <FileNavigatorSettings /> },
+        { label: t('settings.about.tab-name'), panel: <AboutPage /> }
+    ];
 
     return (
         <Box
@@ -36,28 +46,16 @@ export default function SettingsView() {
                 aria-label="setttings tabs"
                 sx={{ borderRight: 2, borderColor: 'divider' }}
             >
-                <Tab label={t('settings.general.tab-name')} />
-                <Tab label={t('settings.rendering.tab-name')} />
-                <Tab label={t('settings.developer.tab-name')} />
-                <Tab label={t('settings.file-navigator.tab-name')} />
-                <Tab label={t('settings.about.tab-name')} />
+                {tabs.map((tab, index) => (
+                    <Tab key={index} label={tab.label} />
+                ))}
             </Tabs>
             <Box sx={{ padding: "12px", width: '100%', height: '100%', overflow: 'auto', bgcolor: (theme) => theme.palette.background.default }}>
-                <TabPanel value={value} index={0}>
-                    <GeneralSettings />
-                </TabPanel>
-                <TabPanel value={value} index={1}>
-                    <RenderingSettings />
-                </TabPanel>
-                <TabPanel value={value} index={2}>
-                    <DeveloperSettings />
-                </TabPanel>
-                <TabPanel value={value} index={3}>
-                    <FileNavigatorSettings />
-                </TabPanel>
-                <TabPanel value={value} index={4}>
-                    <AboutPage />
-                </TabPanel>
+                {tabs.map((tab, index) => (
+                    <TabPanel value={value} index={index} key={index}>
+                        {tab.panel}
+                    </TabPanel>
+                ))}
             </Box>
         </Box >
     );

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -25,6 +25,13 @@
                 "dark": "Dark"
             }
         },
+        "page": {
+            "tab-name": "Page",
+            "title": "Page",
+            "first-page": {
+                "title": "Show the initial page in single-page view: "
+            }
+        },
         "file-navigator": {
             "tab-name": "File Navigator",
             "title": "File Navigator",

--- a/src/i18n/locales/ja-JP.json
+++ b/src/i18n/locales/ja-JP.json
@@ -25,6 +25,13 @@
                 "dark": "ダークテーマ"
             }
         },
+        "page": {
+            "tab-name": "ページ",
+            "title": "ページ",
+            "first-page": {
+                "title": "最初のページを 1 ページ表示する: "
+            }
+        },
         "file-navigator": {
             "tab-name": "ファイルナビゲーター",
             "title": "ファイルナビゲーター",

--- a/src/reducers/ViewReducer.tsx
+++ b/src/reducers/ViewReducer.tsx
@@ -6,6 +6,7 @@ export const viewSlice = createSlice({
     initialState: {
         isTwoPagedView: true,
         direction: "rtl" as Direction,
+        isFirstPageSingleView: true,
     },
     reducers: {
         setIsTwoPagedView: (state, action: PayloadAction<boolean>) => {
@@ -13,9 +14,12 @@ export const viewSlice = createSlice({
         },
         setDirection: (state, action: PayloadAction<Direction>) => {
             state.direction = action.payload;
-        }
+        },
+        setIsFirstPageSingleView: (state, action: PayloadAction<boolean>) => {
+            state.isFirstPageSingleView = action.payload;
+        },
     }
 });
 
-export const { setIsTwoPagedView, setDirection } = viewSlice.actions;
+export const { setIsTwoPagedView, setDirection, setIsFirstPageSingleView } = viewSlice.actions;
 export default viewSlice.reducer;


### PR DESCRIPTION
* 最初の最初のページを1ページ表示できるように ImageViewer を変更
* 設定画面にページ設定を追加し、最初のページの表示方法を変更できるようにする
   * WebView ごとに Store が独立しているので、メインウィンドウに反映するために event を利用