### PR TITLE
ツールチップをカーソル位置に表示することでスクロールしやすくする

### DIFF
--- a/src/components/FileNavigator/ItemRow.tsx
+++ b/src/components/FileNavigator/ItemRow.tsx
@@ -22,7 +22,7 @@ export const ItemRow = memo(function ItemRow({
     style: CSSProperties | undefined
 }) {
     return (
-        <Tooltip title={entry.name} placement="right-start">
+        <Tooltip title={entry.name} followCursor placement="right-start">
             <ListItem style={style} key={index} component="div" disablePadding dense>
                 <ListItemButton
                     selected={selected}

--- a/src/components/ImageEntriesViewer/ItemRow.tsx
+++ b/src/components/ImageEntriesViewer/ItemRow.tsx
@@ -19,7 +19,7 @@ export const ItemRow = memo(function ItemRow({
     style: CSSProperties | undefined
 }) {
     return (
-        <Tooltip title={entry} placement="right-start">
+        <Tooltip title={entry} followCursor placement="right-start">
             <ListItem style={style} key={index} component="div" disablePadding dense>
                 <ListItemButton
                     selected={selected}


### PR DESCRIPTION
* スクロールバーの上にツールチップが表示されており、スクロールしにくかったため、ツールチップの表示位置を変更