### PR TITLE
言語設定で国コードがない場合にも対応

### DIFF
--- a/src/components/Settings/GeneralSettings/Items/LanguageSettings.tsx
+++ b/src/components/Settings/GeneralSettings/Items/LanguageSettings.tsx
@@ -18,7 +18,7 @@ import { Language } from "@mui/icons-material";
  */
 export default function LanguageSetting() {
   const [t, i18n] = useTranslation();
-  const [language, setLanguage] = useState<string>(i18n.languages[0]);
+  const [language, setLanguage] = useState<string>(i18n.resolvedLanguage ?? "en-US");
 
   const handleLanguageChanged = async (e: SelectChangeEvent) => {
     setLanguage(e.target.value);

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -7,7 +7,11 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: "en-US",
+    fallbackLng: {
+      en: ["en-US"],
+      ja: ["ja-JP"],
+      default: ["en-US"],
+    },
     resources: {
       "en-US": {
         translation: translationEnUs,


### PR DESCRIPTION
* 言語コードのみで国コードがない場合("ja"など)の場合に、フォールバックするようにする
* 設定画面のセレクトで設定中の値はi18nで解決された値に変更