### PR TITLE
github actions で cargo のキャッシュをしてビルド時間を短縮する

### DIFF
--- a/.github/workflows/build-app-actions.yml
+++ b/.github/workflows/build-app-actions.yml
@@ -35,6 +35,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri -> target"
+
       - name: Install frontend dependencies
         run: yarn install
 


### PR DESCRIPTION
* Swatinem/rust-cache@v2 でビルドキャッシュを有効にする