### PR TITLE
fix: book loading logic and progress display

### DIFF
--- a/src/features/BookReader/slice.ts
+++ b/src/features/BookReader/slice.ts
@@ -32,22 +32,9 @@ export const openContainerFile = createAppAsyncThunk(
     try {
       const isEpubNovel = await determineEpubNovel(path);
 
-      const bookByPath = await getBookWithStateById(
-        await upsertReadBook({
-          filePath: path,
-          itemType: "file", // Temporary, will be updated below
-          totalPages: 0,
-          displayName: await basename(path),
-        }),
-      );
-      const startIndex = bookByPath?.last_read_page_index ?? 0;
-
       let entriesResult: { entries: string[]; is_directory: boolean } | undefined;
       if (!isEpubNovel) {
         entriesResult = await getEntriesInContainer(path);
-        requestPreloadAround(startIndex, entriesResult.entries.length).catch((e) => {
-          error(`Failed to request preload: ${String(e)}`);
-        });
         debug(
           `openContainerFile: Retrieved ${entriesResult.entries.length} entries. (Container is directory: ${entriesResult.is_directory})`,
         );
@@ -69,6 +56,13 @@ export const openContainerFile = createAppAsyncThunk(
       });
 
       const book = await getBookWithStateById(bookId);
+
+      if (!isEpubNovel) {
+        const startIndex = book?.last_read_page_index ?? 0;
+        requestPreloadAround(startIndex, entriesResult?.entries.length).catch((e) => {
+          error(`Failed to request preload: ${String(e)}`);
+        });
+      }
 
       return {
         entries: entriesResult?.entries,

--- a/src/features/Bookshelf/components/BookCard.tsx
+++ b/src/features/Bookshelf/components/BookCard.tsx
@@ -173,7 +173,7 @@ function BookCardInner({
                 variant="determinate"
                 value={
                   book.total_pages !== 0
-                    ? ((book.last_read_page_index ? book.last_read_page_index + 1 : 1) /
+                    ? ((book.last_read_page_index ? book.last_read_page_index + 1 : 0) /
                         book.total_pages) *
                       100
                     : 0


### PR DESCRIPTION
## Description

- Refactor `openContainerFile` to remove redundant database upsert operations.
- Relocate preloading logic to execute after the correct book state is established.
- Fix progress bar calculation in `BookCard` to correctly handle unread books by defaulting to 0 instead of 1.

## Related Issue

None.

## Type of Change
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Refactoring (code changes that neither fix a bug nor add a feature)
* [ ] Dependency update (updates to dependencies or packages)
* [ ] Documentation update
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in English, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings (e.g., passed `cargo clippy` for Rust, Biome check for frontend).
* [x] I have tested that the app builds successfully across target platforms.

## Screenshots (if appropriate):

None.
