### PR TITLE
Fix re-entrancy panic and improve image processing quality

### DIFF
--- a/src-tauri/src/image/resizer.rs
+++ b/src-tauri/src/image/resizer.rs
@@ -91,7 +91,18 @@ pub fn resize_exact(
     let options_alpha = ResizeOptions::new().resize_alg(alg).use_alpha(true);
 
     RESIZER.with(|resizer_cell| -> Result<DynamicImage> {
-        let mut resizer = resizer_cell.borrow_mut();
+        // Fallback to a new Resizer if the thread-local one is already borrowed.
+        // This can happen in Rayon worker threads due to work-stealing when
+        // fast_image_resize itself uses Rayon internally.
+        let mut borrow = resizer_cell.try_borrow_mut();
+        let mut fallback_resizer;
+        let resizer = match borrow.as_mut() {
+            Ok(b) => &mut **b,
+            Err(_) => {
+                fallback_resizer = Resizer::new();
+                &mut fallback_resizer
+            }
+        };
 
         macro_rules! resize_to {
             ($src:expr, $image_type:path, $variant:ident, $options:expr) => {{


### PR DESCRIPTION
## Description

- Fix RefCell panic in Rayon worker threads by implementing a fallback Resizer.
- Use a macro to DRY the resize logic and add native 16-bit/32-bit float support.

## Related Issue

None.

## Type of Change
* [ ] New feature (non-breaking change which adds functionality)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Refactoring (code changes that neither fix a bug nor add a feature)
* [ ] Dependency update (updates to dependencies or packages)
* [ ] Documentation update
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in English, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings (e.g., passed `cargo clippy` for Rust, Biome check for frontend).
* [x] I have tested that the app builds successfully across target platforms.

## Screenshots (if appropriate):

None.