### PR TITLE
Improve series reordering UI and stabilize drag-and-drop behavior

### DIFF
--- a/src/features/Bookshelf/components/Dialog/EditSeriesOrderDialog.tsx
+++ b/src/features/Bookshelf/components/Dialog/EditSeriesOrderDialog.tsx
@@ -7,7 +7,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import {
   arrayMove,
   SortableContext,
@@ -70,14 +70,14 @@ export default function EditSeriesOrderDialog({
   };
 
   return (
-    <Dialog open={openDialog} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog open={openDialog} onClose={onClose}>
       <DialogTitle>{t("bookshelf.series.edit-order.title")}</DialogTitle>
-      <DialogContent dividers sx={{ p: 1, overflowX: "hidden" }}>
+      <DialogContent sx={{ padding: 1, overflowX: "hidden" }}>
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
-          modifiers={[restrictToVerticalAxis]}
+          modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
         >
           <SortableContext
             items={orderedBooks.map((b) => b.id)}
@@ -91,7 +91,7 @@ export default function EditSeriesOrderDialog({
           </SortableContext>
         </DndContext>
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={{ paddingBottom: 3, paddingRight: 3 }}>
         <Button onClick={onClose} sx={{ color: "text.secondary" }}>
           {t("bookshelf.collection.cancel-button")}
         </Button>

--- a/src/features/Bookshelf/components/Dialog/SortableBookItem.tsx
+++ b/src/features/Bookshelf/components/Dialog/SortableBookItem.tsx
@@ -32,7 +32,7 @@ export default function SortableBookItem({ book, index }: SortableBookItemProps)
         border: "1px solid",
         borderColor: "divider",
         borderRadius: 1,
-        mb: 1,
+        marginBottom: 1,
       }}
       secondaryAction={
         <Box {...attributes} {...listeners} sx={{ display: "flex", alignItems: "center" }}>
@@ -46,7 +46,14 @@ export default function SortableBookItem({ book, index }: SortableBookItemProps)
         <Avatar
           variant="rounded"
           src={book?.thumbnail_path ? convertFileSrc(book.thumbnail_path) : dummy_thumbnail}
-          sx={{ width: 40, height: 56 }}
+          sx={{
+            width: 60,
+            height: 80,
+            bgcolor: "background.paper",
+            "& img": {
+              objectFit: "contain",
+            },
+          }}
         >
           {!book.thumbnail_path && book.display_name.charAt(0)}
         </Avatar>
@@ -54,10 +61,14 @@ export default function SortableBookItem({ book, index }: SortableBookItemProps)
       <ListItemText
         primary={book.display_name}
         secondary={`# ${index + 1}`}
-        primaryTypographyProps={{
-          noWrap: true,
-          title: book.display_name,
+        slotProps={{
+          primary: {
+            sx: {
+              wordBreak: "break-all",
+            },
+          },
         }}
+        sx={{ marginLeft: 2 }}
       />
     </ListItem>
   );

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -85,7 +85,7 @@ function closeTauriDriver() {
   tauriDriver?.kill();
 }
 
-function onShutdown(fn) {
+function onShutdown(fn: () => void) {
   const cleanup = () => {
     try {
       fn();


### PR DESCRIPTION
## Description

- Fixed D&D Stability: Added `restrictToFirstScrollableAncestor` to prevent erratic item behavior while dragging in a scrollable container.
- Improved Visibility:
    - Enlarged thumbnails (`60x80`) with `object-fit: contain`.
    - Enabled title word-wrapping for long strings using `word-break: break-all`.
- Refined Layout: Adjusted dialog padding and dimensions for a cleaner UI.
- Type Safety: Added missing type definition for `onShutdown` in `wdio.conf.ts`.

## Related Issue

None.

## Type of Change
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Refactoring (code changes that neither fix a bug nor add a feature)
* [ ] Dependency update (updates to dependencies or packages)
* [ ] Documentation update
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in English, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings (e.g., passed `cargo clippy` for Rust, Biome check for frontend).
* [x] I have tested that the app builds successfully across target platforms.

## Screenshots (if appropriate):
None.