### PR TITLE
Cache CSS selector for images in EPUB container

### DIFF
--- a/src-tauri/src/container/epub_container.rs
+++ b/src-tauri/src/container/epub_container.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     io::Cursor,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use image::{codecs::jpeg::JpegEncoder, ImageReader};
@@ -156,12 +156,32 @@ fn create_thumbnail(epub: &mut Epub, entry: &str) -> Result<Arc<Image>> {
     }))
 }
 
+/// Returns the thread-safe CSS selector for images within EPUB content.
+///
+/// This selector is lazily initialized and cached to avoid repeated parsing overhead.
+///
+/// # Returns
+///
+/// `Some(&Selector)` on success, or `None` on failure.
+fn get_image_selector() -> Option<&'static Selector> {
+    static SELECTOR: OnceLock<Option<Selector>> = OnceLock::new();
+    SELECTOR
+        .get_or_init(|| {
+            Selector::parse("img, image")
+                .map_err(|e| log::error!("Failed to parse CSS selector for EPUB images: {:?}", e))
+                .ok()
+        })
+        .as_ref()
+}
+
 /// Parses the EPUB's spine to determine the order of images as they appear in the content.
 ///
 /// Returns a `HashMap` mapping image resource IDs to their sequential order.
 fn create_image_order_map(epub: &mut Epub) -> Option<HashMap<String, usize>> {
     let mut map = HashMap::new();
     let mut current_order = 0;
+
+    let selector = get_image_selector()?;
 
     let mut reader = epub.reader();
     while let Some(Ok(page)) = reader.read_next() {
@@ -173,8 +193,7 @@ fn create_image_order_map(epub: &mut Epub) -> Option<HashMap<String, usize>> {
             continue;
         };
         let document = Html::parse_document(&content);
-        let selector = Selector::parse("img, image").unwrap();
-        for element in document.select(&selector) {
+        for element in document.select(selector) {
             let src_attr = element
                 .value()
                 .attr("src")

--- a/src/store/middleware/loggerMiddleware.ts
+++ b/src/store/middleware/loggerMiddleware.ts
@@ -7,7 +7,7 @@ import { debug, trace } from "@tauri-apps/plugin-log";
  * @param data - The data to check.
  * @returns True if the data is likely too large to be logged, false otherwise.
  */
-function isLikelyTooLargeStrinct(data: unknown): boolean {
+function isLikelyTooLargeStrict(data: unknown): boolean {
   if (Array.isArray(data) && data.length > 10) {
     return true;
   }
@@ -24,7 +24,7 @@ function isLikelyTooLargeStrinct(data: unknown): boolean {
       }
 
       const prop = (data as Record<string, unknown>)[key];
-      if (prop && typeof prop === "object" && isLikelyTooLargeStrinct(prop)) {
+      if (prop && typeof prop === "object" && isLikelyTooLargeStrict(prop)) {
         return true;
       }
     }
@@ -35,7 +35,7 @@ function isLikelyTooLargeStrinct(data: unknown): boolean {
 
 export const loggerMiddleware: Middleware = (store) => (next) => (action: unknown) => {
   if (typeof action === "object" && action !== null && "type" in action && "payload" in action) {
-    if (isLikelyTooLargeStrinct(action.payload)) {
+    if (isLikelyTooLargeStrict(action.payload)) {
       debug(`Dispatching action. type:${action.type}}, payload: Large Object(Suppressed)`);
       trace(`Dispatching action. type:${action.type}}, payload:${JSON.stringify(action.payload)}`);
     } else {


### PR DESCRIPTION
## Description

- Lazily parse and cache the `"img, image"` CSS selector using `std::sync::OnceLock`.
- Reuse the cached selector in `create_image_order_map` instead of repeatedly parsing it for every chapter page.
- Improve safety by logging parser errors and returning `None` instead of panicking with `unwrap()`.
- Correct spelling of `isLikelyTooLargeStrinct` to `isLikelyTooLargeStrict` in `loggerMiddleware.ts`

## Related Issue

None.

## Type of Change
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Refactoring (code changes that neither fix a bug nor add a feature)
* [ ] Dependency update (updates to dependencies or packages)
* [ ] Documentation update
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in English, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings (e.g., passed `cargo clippy` for Rust, Biome check for frontend).
* [x] I have tested that the app builds successfully across target platforms.

## Screenshots (if appropriate):
None.