### PR TITLE
Align reader-settings docstring and AGENTS.md with current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# RookReader Gemini AI Instructions
+# RookReader AI Agent Instructions
 
-This document provides foundational mandates, project context, and workflows for Gemini AI when assisting with the **RookReader** project. These instructions take absolute precedence.
+This document provides foundational mandates, project context, and workflows for AI agents when assisting with the **RookReader** project. These instructions take absolute precedence.
 
 ## 1. Project Context
 
@@ -20,7 +20,7 @@ This document provides foundational mandates, project context, and workflows for
   - Components are primarily functional React components with hooks.
   - Backend code resides in `src-tauri/src/`.
     - `src-tauri/src/commands/`: Tauri commands exposed to the frontend.
-    - `src-tauri/src/database/`: SQLite database operations via sqlx.
+    - `src-tauri/src/infrastructure/database/`: SQLite database operations via sqlx.
     - `src-tauri/src/container/`: File system access and parsing logic for zip, rar, pdf, and epub formats.
   - State management is handled by Redux Toolkit for complex global state, and React hooks for local state.
 - **Coding Standards:**
@@ -55,12 +55,12 @@ This document provides foundational mandates, project context, and workflows for
   - `sqlx migrate add -r <name>`: Creates a new migration file (`<timestamp>_<name>.up.sql` and `<timestamp>_<name>.down.sql`).
   - `cargo sqlx prepare`: Generates the `query-*.json` files required for OFFLINE builds. Ensure this is run after any schema or query changes.
 
-## 3. Core Mandates for Gemini AI
+## 3. Core Mandates for AI Agents
 
 1.  **Understand the Architecture:** When adding a new feature that touches both frontend and backend, ensure you:
-    - Create or update the Rust core logic (e.g., in `src-tauri/src/database/` or `src-tauri/src/container/`).
+    - Create or update the Rust core logic (e.g., in `src-tauri/src/infrastructure/database/` or `src-tauri/src/container/`).
     - Create or update the Tauri command in `src-tauri/src/commands/`.
-    - Register the command in `src-tauri/src/lib.rs` (collected in `specta_builder()`).
+    - Register the command in `src-tauri/src/lib.rs`: specta-compatible commands go in `specta_builder()` (`collect_commands!`); binary commands returning a raw `tauri::ipc::Response` are instead added to the small separate `generate_handler!` and routed by command name.
     - Regenerate the TypeScript bindings (`npm run gen:bindings`, which writes the `tauri-specta`-generated
       `src/bindings/bindings.ts`), then add/update the thin wrapper in `src/bindings/*Commands.ts` that
       delegates to the generated `commands.*` (binary `tauri::ipc::Response` commands keep a raw `invoke`).

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -83,11 +83,18 @@ pub fn setup_container_settings(app: &App, settings: &AppSettings) -> error::Res
     Ok(())
 }
 
-/// Applies the reader/rendering settings to the live container runtime state.
+/// Applies the reader/rendering settings to the container runtime state.
 ///
-/// This reflects the persisted settings into `ContainerState`, so changes take effect
-/// without a restart. The image cache is rebuilt **only when its capacity changed**,
-/// because rebuilding evicts every cached image.
+/// This copies the persisted reader/rendering values into `ContainerState::settings`.
+/// Only the **image cache capacity** is applied to the currently-open container live:
+/// when it changes, the cache is rebuilt (which evicts every cached image) and handed to
+/// the open `ImageLoader`.
+///
+/// The other values (`max_image_height`, `image_resampling_method`,
+/// `pdf_render_resolution_height`, `enable_preview`) are stored for the **next**
+/// `ContainerState::open_container` call: the already-open `ImageLoader` captured its
+/// resize height/method at construction, so changing them does not re-render the book
+/// currently on screen — it takes effect when a container is next opened.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
## Description

- Correct the apply_reader_settings_to_container docstring: only the image cache capacity is applied live to the open container; max_image_height / image_resampling_method / pdf_render_resolution_height / enable_preview take effect on the next open_container (the open ImageLoader fixes its resize height/method at construction).
- Fix AGENTS.md drift: correct the database module path to src-tauri/src/infrastructure/database/, and align the command-registration description with the actual specta_builder() + binary generate_handler! split.
- Generalize Gemini-specific wording to tool-neutral "AI agents".

## Related Issue

None.

## Type of Change
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Refactoring (code changes that neither fix a bug nor add a feature)
* [ ] Dependency update (updates to dependencies or packages)
* [x] Documentation update
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in English, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings (e.g., passed `cargo clippy` for Rust, Biome check for frontend).
* [x] I have tested that the app builds successfully across target platforms.

## Screenshots (if appropriate):

None.
