### PR TITLE
Migrate to @wdio/tauri-service 1.2.0 embedded provider + hermetic data dir

### DIFF
--- a/.github/workflows/build-app-actions.yml
+++ b/.github/workflows/build-app-actions.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf webkit2gtk-driver
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run e2e tests (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'
-        run: npm run test:e2e
+        run: xvfb-run --auto-servernum -- npm run test:e2e
 
       - name: Build and upload artifacts.
         uses: tauri-apps/tauri-action@dev # use dev to upload artifacts.

--- a/.github/workflows/full-validation.yml
+++ b/.github/workflows/full-validation.yml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf webkit2gtk-driver
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
@@ -83,8 +83,8 @@ jobs:
 
       - name: Run e2e tests on ubuntu
         if: matrix.platform == 'ubuntu-latest'
-        run: npm run test:e2e
+        run: xvfb-run --auto-servernum -- npm run test:e2e
 
       - name: Run e2e tests on windows
         if: matrix.platform == 'windows-latest'
-        run: npm run test:e2e:win
+        run: npm run test:e2e

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf webkit2gtk-driver
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xvfb
 
       - name: Install frontend dependencies
         run: npm ci
@@ -59,11 +59,11 @@ jobs:
 
       - name: Run e2e tests on ubuntu
         if: matrix.platform == 'ubuntu-latest'
-        run: npm run test:e2e
+        run: xvfb-run --auto-servernum -- npm run test:e2e
 
       - name: Run e2e tests on windows
         if: matrix.platform == 'windows-latest'
-        run: npm run test:e2e:win
+        run: npm run test:e2e
 
       - name: Generate Release Body
         id: generate-release-body

--- a/e2e/input.ts
+++ b/e2e/input.ts
@@ -1,0 +1,54 @@
+import { $, browser } from "@wdio/globals";
+
+/**
+ * Reader input operations that the embedded @wdio/tauri-service provider (1.2.0) cannot
+ * drive faithfully, isolated here so the specs express intent and the workarounds can be
+ * swapped out in one place once the provider is fixed.
+ *
+ * The provider does not drive OS-level input; it synthesizes JS DOM events
+ * (`tauri-plugin-wdio-webdriver` `platform/executor.rs`), and two operations have gaps:
+ *   - Right-click: only a `click` is synthesized for the primary button; `contextmenu` is
+ *     never emitted, so `onContextMenu` handlers never fire.
+ *   - Arrow keys: `keydown` is dispatched to `document.activeElement`, which after loading
+ *     a book is a text input; the app ignores key events from inputs (see usePageNavigation),
+ *     so navigation keys are swallowed.
+ * Left-click already works through the provider, so specs call `element.click()` directly.
+ *
+ * WHEN THE PROVIDER IS FIXED, replace ONLY the marked body of each function with the real
+ * WebDriver call shown in its comment; the specs that call these stay unchanged.
+ */
+
+/** Navigation keys understood by the reader's window keydown listener. */
+export type NavigationKey = "ArrowLeft" | "ArrowRight";
+
+/**
+ * Right-clicks the target. In the reader this moves the page back.
+ *
+ * PROVIDER-WORKAROUND — emulates the browser's `contextmenu` event. When the provider
+ * synthesizes right-click, replace the body with:
+ *   const element = $(selector);
+ *   await element.waitForDisplayed();
+ *   await element.click({ button: "right" });
+ */
+export async function rightClick(selector: string): Promise<void> {
+  await $(selector).waitForDisplayed();
+  await browser.execute((sel: string) => {
+    document
+      .querySelector(sel)
+      ?.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+  }, selector);
+}
+
+/**
+ * Presses a navigation key. The reader listens for keydown on `window`.
+ *
+ * PROVIDER-WORKAROUND — dispatches `keydown` to `window`, bypassing the
+ * activeElement/input-focus issue described above. When the provider routes keys
+ * faithfully, replace the body with:
+ *   await browser.keys(key); // key is the literal "ArrowLeft" / "ArrowRight"
+ */
+export async function pressKey(key: NavigationKey): Promise<void> {
+  await browser.execute((k: string) => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }));
+  }, key);
+}

--- a/e2e/specs/app.spec.ts
+++ b/e2e/specs/app.spec.ts
@@ -51,5 +51,10 @@ describe("RookReader Application E2E Tests", () => {
     const settingsTabs = $('[aria-label="setttings tabs"]');
     await settingsTabs.waitForExist();
     await expect(settingsTabs).toExist();
+
+    // Close the settings window and return to the main window so later specs (which share
+    // this single app instance) run against one window and not the leftover settings window.
+    await browser.closeWindow();
+    await browser.switchToWindow(mainWindowHandle);
   });
 });

--- a/e2e/specs/page-navigation.spec.ts
+++ b/e2e/specs/page-navigation.spec.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { $, browser, expect } from "@wdio/globals";
-import { Key } from "webdriverio";
+import { pressKey, rightClick } from "../input";
 
 describe("RookReader E2E Tests - Page Navigation", () => {
   it("should load a directory and navigate pages", async () => {
@@ -23,16 +23,14 @@ describe("RookReader E2E Tests - Page Navigation", () => {
 
     const dummyPath = path.join(process.cwd(), "e2e", "fixtures", "dummy_book");
 
-    // Clear the path input manually since clearValue() won't work here.
-    await pathInput.click();
-    await browser.keys([Key.Ctrl, "a"]);
-    await browser.keys(Key.Delete);
-
-    await pathInput.addValue(dummyPath);
-    await browser.keys(Key.Enter);
-
-    // Wait for the loading images to finish.
-    await browser.pause(1000);
+    // Submit the container-path form directly: the embedded WebDriver provider cannot
+    // reliably submit via the Enter key, so drive the same submit the input's onBlur uses.
+    await pathInput.setValue(dummyPath);
+    await browser.execute(() => {
+      document
+        .querySelector<HTMLInputElement>('input[aria-label="container-path-input"]')
+        ?.form?.requestSubmit();
+    });
 
     const pageIndicator = $('[aria-label="page-indicator"]');
     await pageIndicator.waitForDisplayed();
@@ -62,15 +60,7 @@ describe("RookReader E2E Tests - Page Navigation", () => {
 
     // Test right click navigation
     currentText = await pageIndicator.getText();
-    // Workaround for Linux where standard `click({ button: "right" })` is flaky.
-    // Using the W3C Action API with a slight pause ensures the `contextmenu` event fires reliably.
-    await browser
-      .action("pointer")
-      .move({ origin: await comicReaderArea })
-      .down({ button: 2 })
-      .pause(20)
-      .up({ button: 2 })
-      .perform();
+    await rightClick('[data-testid="comic-reader-area"]');
 
     await browser.waitUntil(
       async () => {
@@ -82,7 +72,7 @@ describe("RookReader E2E Tests - Page Navigation", () => {
 
     // Test keyboard navigation
     currentText = await pageIndicator.getText();
-    await comicReaderArea.addValue(Key.ArrowLeft);
+    await pressKey("ArrowLeft");
 
     await browser.waitUntil(
       async () => {
@@ -93,7 +83,7 @@ describe("RookReader E2E Tests - Page Navigation", () => {
     );
 
     currentText = await pageIndicator.getText();
-    await comicReaderArea.addValue(Key.ArrowRight);
+    await pressKey("ArrowRight");
 
     await browser.waitUntil(
       async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,8 @@
         "@wdio/local-runner": "^9.27.0",
         "@wdio/mocha-framework": "^9.27.0",
         "@wdio/spec-reporter": "^9.27.0",
-        "@wdio/tauri-service": "1.0.0",
+        "@wdio/tauri-plugin": "1.2.0",
+        "@wdio/tauri-service": "1.2.0",
         "expect-webdriverio": "^5.6.5",
         "jiti": "^2.6.1",
         "jsdom": "^29.0.1",
@@ -951,9 +952,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -968,9 +969,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -985,9 +986,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -1002,9 +1003,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -1019,9 +1020,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1036,9 +1037,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -1053,9 +1054,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -1070,9 +1071,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1088,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -1104,9 +1105,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -1121,9 +1122,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -1138,9 +1139,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -1155,9 +1156,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1172,9 +1173,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1189,9 +1190,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1206,9 +1207,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1223,9 +1224,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1240,9 +1241,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1257,9 +1258,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1274,9 +1275,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1291,9 +1292,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1308,9 +1309,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1325,9 +1326,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1342,9 +1343,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1359,9 +1360,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1376,9 +1377,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -3784,10 +3785,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@wdio/native-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wdio/native-core/-/native-core-1.0.0.tgz",
+      "integrity": "sha512-SBVipUZk1+fiwwyGkDjp0gZsV+AGlZ1NE3rPviPCzs6QKm6Qmj7di/05P5MdqYUq/PslrVEWNIp6TYfL+wjEKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "9.18.0",
+        "@wdio/native-types": "2.3.1",
+        "@wdio/native-utils": "2.4.0",
+        "debug": "^4.4.3",
+        "get-port": "^7.1.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+      }
+    },
+    "node_modules/@wdio/native-core/node_modules/@wdio/logger": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/native-core/node_modules/@wdio/native-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@wdio/native-types/-/native-types-2.3.1.tgz",
+      "integrity": "sha512-q6BOAd7Yg8lQJJWW/z1a4ratTttMIy39MfbAIgw8PKrXB6Oc+x95KXkuIcCGDINTk+X92Lbjxefiww4jiPam8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+      }
+    },
     "node_modules/@wdio/native-spy": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@wdio/native-spy/-/native-spy-1.0.10.tgz",
-      "integrity": "sha512-RKl7EwJCMteMDk3vRkBGpocgBd5U1Hhcl4Diyg0jw71K0UDSbvCnzIHVzLoMQYv3hn/dwokvNRoW3jllOMC37A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wdio/native-spy/-/native-spy-1.1.0.tgz",
+      "integrity": "sha512-1BTbiWo9fNOsnSRYTjBE0Z6PtknFMtN7/TH2SsnishkIABUHH8ONKB+NWiTCiX8IkFiARguo2bJHEQBOULXlwA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3795,9 +3841,9 @@
       }
     },
     "node_modules/@wdio/native-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@wdio/native-types/-/native-types-2.2.0.tgz",
-      "integrity": "sha512-vaPUfOaV0gy/WzSlyDQOH6x6lOrcZPyYnoiKopnLIruj/x+Rg5/CUjWxlU9vEppr4s9ClfxnWj1T83CR56fM4Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@wdio/native-types/-/native-types-2.4.0.tgz",
+      "integrity": "sha512-GjgPskOoTvl17Jwj8aAU3A31gpklL5M1KfbrwYffbQT16CTpJTD8A4PdoS2ZjGoCWcyLBR1CWdJI3W8T0JBLjw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3805,23 +3851,47 @@
       }
     },
     "node_modules/@wdio/native-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wdio/native-utils/-/native-utils-2.3.0.tgz",
-      "integrity": "sha512-0qv0/GYPVTwHm6o/xVat4+TjDPeRa6gMefCzEAuJHdBPdkob9Oc0IVlx8zjWj1pDZW4twM8DlAGQgvWA4BkWVQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wdio/native-utils/-/native-utils-2.5.0.tgz",
+      "integrity": "sha512-Qv0mJ2elRBZCgYbHCnKPNgE9VaqnmNJyjythTDYyOQpj8pAs6FZXXmWXGkUIdMds5cK0ux/qtxyKU0Y0tDsUUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.18.0",
+        "@wdio/logger": "9.18.0",
         "debug": "^4.4.3",
-        "esbuild": "^0.27.4",
+        "esbuild": "^0.28.0",
         "find-up-simple": "^1.0.1",
         "json5": "^2.2.3",
         "smol-toml": "^1.6.0",
-        "tsx": "^4.21.0",
-        "yaml": "^2.8.2"
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+      },
+      "peerDependencies": {
+        "tsx": "^4.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tsx": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wdio/native-utils/node_modules/@wdio/logger": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/protocols": {
@@ -3963,24 +4033,52 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/tauri-service": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@wdio/tauri-service/-/tauri-service-1.0.0.tgz",
-      "integrity": "sha512-o8NDK5nEwJxuEmsM7tGdySCwiWxkSjmffABHQFwh+J0b8FQYxSVgKFFf5y8ve2mIFGTsf85YrD46tGgts6A39A==",
+    "node_modules/@wdio/tauri-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@wdio/tauri-plugin/-/tauri-plugin-1.2.0.tgz",
+      "integrity": "sha512-qeQQ4D0Q4BkwC+Cyez1I343DRm9UErCXksZ/DN1qCpJCorEEPKL3IiYb34OtNJBgnbhqwtGukyjOZYvnpPz95A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/globals": "^9.27.0",
-        "@wdio/logger": "^9.18.0",
-        "@wdio/native-spy": "1.0.10",
-        "@wdio/native-types": "2.2.0",
-        "@wdio/native-utils": "2.3.0",
-        "@wdio/spec-reporter": "^9.27.0",
-        "@wdio/types": "9.27.0",
+        "@tauri-apps/api": "2.11.0",
+        "@tauri-apps/plugin-log": "2.8.0",
+        "@wdio/native-spy": "1.1.0",
+        "@wdio/native-utils": "2.4.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
+      }
+    },
+    "node_modules/@wdio/tauri-plugin/node_modules/@tauri-apps/api": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@wdio/tauri-service": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@wdio/tauri-service/-/tauri-service-1.2.0.tgz",
+      "integrity": "sha512-/PEmbDKra6Lsodes5x1Sg5H98bG4hObYZWMyrlbv0e5fL0KVMQMxDP798jWWIqT6+iOPsIlkLirRJKfXXGVtsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/globals": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/native-core": "1.0.0",
+        "@wdio/native-spy": "1.1.0",
+        "@wdio/native-types": "2.4.0",
+        "@wdio/native-utils": "2.4.0",
+        "@wdio/spec-reporter": "9.27.1",
+        "@wdio/types": "9.27.1",
         "debug": "^4.4.3",
         "get-port": "^7.1.0",
         "tslib": "^2.8.1",
-        "webdriverio": "^9.27.0"
+        "webdriverio": "9.27.1"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.11.0"
@@ -4004,10 +4102,109 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/config": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.27.1.tgz",
+      "integrity": "sha512-QVfSCqcpMfVum9KlpxgjaLlSLXkc53UQ2CPJU+IUVBp8LkbSyeX972HQS8V9Hnn6vSPE1dYScItg7wblnJ8RQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0",
+        "jiti": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/globals": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.27.1.tgz",
+      "integrity": "sha512-jm6gTQ6Qo3EOBY6PA09U/5Pf17WLEJM1/lTfhc6jzLFE770EuhuhbuphqrInH0hVR9WMyWtSZQ+LRCcLfcmOPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "expect-webdriverio": "^5.6.5",
+        "webdriverio": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expect-webdriverio": {
+          "optional": false
+        },
+        "webdriverio": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/logger": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/protocols": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.27.1.tgz",
+      "integrity": "sha512-Ril46AmySoiYX9nuKqFr3SNJqquU3VmF9FzSndQlDib0G3oA4pYx9wcBXvdvkFxRjjmFwQDzmvztKrssAHymgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/reporter": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.27.1.tgz",
+      "integrity": "sha512-2ueVjd5hOCclfC+GV3yhaN/4Tids1mXMcpPtNTPushHIQY4gLmBqqKDe5RSXAED3bNU+DRdHq2uBiZTBd4QDJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "diff": "^8.0.2",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/spec-reporter": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-9.27.1.tgz",
+      "integrity": "sha512-q9UMJJbCcP+nCOojIvOIcsXnerhHICmWu94guRMRYPbW2IsG/5VM/uhzwru8SU/1WRXLtKgTjkuXXsjzjVpf2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.27.1",
+        "@wdio/types": "9.27.1",
+        "chalk": "^5.1.2",
+        "easy-table": "^1.2.0",
+        "pretty-ms": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
     "node_modules/@wdio/tauri-service/node_modules/@wdio/types": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.27.0.tgz",
-      "integrity": "sha512-DQJ+OdRBqUBcQ30DN2Z651hEVh3OoxnlDUSRqlWy9An2AY6v9rYWTj825B6zsj5pLLEToYO1tfwWq0ab183pXg==",
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.27.1.tgz",
+      "integrity": "sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4017,12 +4214,116 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/tauri-service/node_modules/@wdio/utils": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.27.1.tgz",
+      "integrity": "sha512-s2w1tFrvmpdkZ33LYsIw4ONRdWIIm4MxkyIuibbcG1ILV5fFMS9rU59csHuWIM0KhJoEoLU+fzE3ze9O7TpWhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.27.1",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/tauri-service/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@wdio/tauri-service/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@wdio/tauri-service/node_modules/webdriver": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.27.1.tgz",
+      "integrity": "sha512-vr6h+RNQ75O2cofgVrdupGxtKjPEBaBYx/lHCHe0giJfAK01oL0U/yrOksJi7kmpev/daN93ldFPhlIlmWtv8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "deepmerge-ts": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
+        "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/tauri-service/node_modules/webdriverio": {
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.27.1.tgz",
+      "integrity": "sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.11.30",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@wdio/config": "9.27.1",
+        "@wdio/logger": "9.18.0",
+        "@wdio/protocols": "9.27.1",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.27.1",
+        "@wdio/utils": "9.27.1",
+        "archiver": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "cheerio": "^1.0.0-rc.12",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "grapheme-splitter": "^1.0.4",
+        "htmlfy": "^0.8.1",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "query-selector-shadow-dom": "^1.0.1",
+        "resq": "^1.11.0",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^12.0.0",
+        "urlpattern-polyfill": "^10.0.0",
+        "webdriver": "9.27.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "puppeteer-core": ">=22.x || <=24.x"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer-core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@wdio/types": {
       "version": "9.29.1",
@@ -5727,9 +6028,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5740,32 +6041,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -11311,490 +11612,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gen:bindings:check": "npm run gen:bindings && git diff --exit-code src/bindings/bindings.ts src/bindings/errorCodes.ts",
     "test:frontend:coverage": "vitest run --coverage",
     "test:e2e": "wdio run wdio.conf.ts",
-    "test:e2e:win": "npm run webdriver:update:win && npm run test:e2e",
     "lint": "biome lint src",
     "lint:fix": "biome lint --write src",
     "format": "biome format --write src",
@@ -24,8 +23,7 @@
     "licenses": "npm run mk-licenses-dir && npm run licenses:frontend && npm run licenses:backend",
     "mk-licenses-dir": "node -e \"require('fs').mkdirSync('src-tauri/target/dependencies/licenses', { recursive: true })\"",
     "licenses:backend": "cargo about generate --manifest-path src-tauri/Cargo.toml src-tauri/about.hbs --output-file src-tauri/target/dependencies/licenses/backend-licenses.html",
-    "licenses:frontend": "npx generate-license-file --input package.json --output src-tauri/target/dependencies/licenses/frontend-licenses.txt --overwrite",
-    "webdriver:update:win": "cargo install --git https://github.com/chippers/msedgedriver-tool && msedgedriver-tool"
+    "licenses:frontend": "npx generate-license-file --input package.json --output src-tauri/target/dependencies/licenses/frontend-licenses.txt --overwrite"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
@@ -82,7 +80,8 @@
     "@wdio/local-runner": "^9.27.0",
     "@wdio/mocha-framework": "^9.27.0",
     "@wdio/spec-reporter": "^9.27.0",
-    "@wdio/tauri-service": "1.0.0",
+    "@wdio/tauri-plugin": "1.2.0",
+    "@wdio/tauri-service": "1.2.0",
     "expect-webdriverio": "^5.6.5",
     "jiti": "^2.6.1",
     "jsdom": "^29.0.1",
@@ -92,6 +91,7 @@
     "vitest": "^4.1.2"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "@wdio/native-utils": "2.5.0"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -295,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
 dependencies = [
  "atk-sys",
- "glib",
+ "glib 0.18.5",
  "libc",
 ]
 
@@ -305,10 +305,10 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -396,6 +396,58 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -664,7 +716,7 @@ checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
  "bitflags 2.13.0",
  "cairo-sys-rs",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "thiserror 1.0.69",
@@ -676,9 +728,9 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -781,7 +833,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -2060,7 +2122,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "pango",
 ]
@@ -2073,7 +2135,7 @@ checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
 ]
@@ -2084,11 +2146,11 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2099,13 +2161,13 @@ checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2115,11 +2177,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
 dependencies = [
  "gdk-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2131,7 +2193,7 @@ dependencies = [
  "gdk",
  "gdkx11-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "x11",
 ]
@@ -2143,9 +2205,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
 dependencies = [
  "gdk-sys",
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -2237,8 +2299,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-util",
- "gio-sys",
- "glib",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pin-project-lite",
@@ -2252,11 +2314,24 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
+dependencies = [
+ "glib-sys 0.21.5",
+ "gobject-sys 0.21.5",
+ "libc",
+ "system-deps 7.0.8",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2271,15 +2346,36 @@ dependencies = [
  "futures-executor",
  "futures-task",
  "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-macros 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "memchr",
  "once_cell",
  "smallvec",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys 0.21.5",
+ "glib-macros 0.21.5",
+ "glib-sys 0.21.5",
+ "gobject-sys 0.21.5",
+ "libc",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -2297,13 +2393,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "glib-macros"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "glib-sys"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
+dependencies = [
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -2318,9 +2437,20 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
+]
+
+[[package]]
+name = "gobject-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
+dependencies = [
+ "glib-sys 0.21.5",
+ "libc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -2336,7 +2466,7 @@ dependencies = [
  "gdk",
  "gdk-pixbuf",
  "gio",
- "glib",
+ "glib 0.18.5",
  "gtk-sys",
  "gtk3-macros",
  "libc",
@@ -2354,12 +2484,12 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2572,6 +2702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2730,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2952,7 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
 dependencies = [
  "bitflags 1.3.2",
- "glib",
+ "glib 0.18.5",
  "javascriptcore-rs-sys",
 ]
 
@@ -2962,10 +3099,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3137,7 +3274,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
 dependencies = [
- "glib",
+ "glib 0.18.5",
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
@@ -3326,6 +3463,12 @@ dependencies = [
  "tendril",
  "web_atoms",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-owned"
@@ -3737,9 +3880,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -3759,6 +3910,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -3820,6 +3972,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,6 +4024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-javascript-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +4055,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3925,6 +4111,8 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-javascript-core",
+ "objc2-security",
 ]
 
 [[package]]
@@ -4040,7 +4228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pango-sys",
@@ -4052,10 +4240,10 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4938,8 +5126,8 @@ checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
  "block2",
  "dispatch2",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk-sys",
  "js-sys",
  "log",
@@ -5043,6 +5231,8 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tauri-plugin-wdio",
+ "tauri-plugin-wdio-webdriver",
  "tauri-plugin-window-state",
  "tauri-specta",
  "tempfile",
@@ -5741,7 +5931,7 @@ checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
 dependencies = [
  "futures-channel",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "soup3-sys",
 ]
@@ -5752,11 +5942,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
 dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -6190,10 +6380,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.8",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -6276,6 +6479,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -6555,6 +6764,56 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip 4.6.1",
+]
+
+[[package]]
+name = "tauri-plugin-wdio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa9b559f110924b9897793767a3bb4880c195db75838030eb224f94d21565d9"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "tauri-plugin-wdio-webdriver"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c5bffe978c41b06ad44a5f4b5b543405918cf316b98756c678a6431061f2e9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "block2",
+ "cairo-rs",
+ "glib 0.21.5",
+ "gtk",
+ "javascriptcore-rs",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-web-kit",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "webkit2gtk",
+ "webview2-com",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7051,6 +7310,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7572,10 +7832,10 @@ dependencies = [
  "gdk",
  "gdk-sys",
  "gio",
- "gio-sys",
- "glib",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk",
  "gtk-sys",
  "javascriptcore-rs",
@@ -7594,15 +7854,15 @@ dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
  "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "gio-sys 0.18.1",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk-sys",
  "javascriptcore-rs-sys",
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,13 @@ repository = "https://github.com/Rookro/RookReader"
 name = "rookreader_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[features]
+# Marks an E2E test build: pulls in the WDIO backend plugin plus the embedded W3C
+# WebDriver server used by the @wdio/tauri-service E2E suite. Enabled only for the E2E
+# build (`tauri build --no-bundle --features e2e-test`); never for shipped/production
+# builds, so the automation servers are not compiled into them.
+e2e-test = ["dep:tauri-plugin-wdio", "dep:tauri-plugin-wdio-webdriver"]
+
 [build-dependencies]
 flate2 = "1.1.9"
 reqwest = { version = "0.13.4", features = ["blocking"] }
@@ -63,6 +70,11 @@ tauri-specta = { version = "=2.0.0-rc.25", features = ["derive", "typescript"] }
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
+# WDIO backend plugin (`/wdio/eval`, log capture) + embedded W3C WebDriver server for the
+# @wdio/tauri-service `embedded` provider. Optional and gated behind the `e2e-test` feature —
+# MUST NOT be enabled for shipped/production builds (they expose automation HTTP servers).
+tauri-plugin-wdio = { version = "1", optional = true }
+tauri-plugin-wdio-webdriver = { version = "1", optional = true }
 
 [dev-dependencies]
 mockall = "0.14.0"

--- a/src-tauri/runtime-capabilities/wdio-webdriver.json
+++ b/src-tauri/runtime-capabilities/wdio-webdriver.json
@@ -1,0 +1,6 @@
+{
+  "identifier": "wdio-webdriver-runtime",
+  "description": "Debug-only WebDriver automation capability, added at runtime for E2E tests.",
+  "windows": ["main", "settings"],
+  "permissions": ["wdio:default", "wdio-webdriver:default"]
+}

--- a/src-tauri/src/commands/book_commands.rs
+++ b/src-tauri/src/commands/book_commands.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use tauri::Emitter;
-use tauri::Manager;
 use tauri::State;
 
 use crate::container::factory::{create_container, ContainerConfig};
@@ -608,7 +607,7 @@ async fn generate_and_save_thumbnail<R: tauri::Runtime>(
         file_path.hash(&mut hasher);
         let hash = hasher.finish();
 
-        let thumbnails_dir = app.path().app_data_dir()?.join("thumbnails");
+        let thumbnails_dir = crate::setup::app_data_dir(&app)?.join("thumbnails");
         if !thumbnails_dir.exists() {
             fs::create_dir_all(&thumbnails_dir)?;
         }
@@ -1104,7 +1103,7 @@ mod tests {
         std::hash::Hash::hash(&file_path, &mut hasher);
         let hash = std::hash::Hasher::finish(&hasher);
 
-        let thumbnails_dir = app.path().app_data_dir().unwrap().join("thumbnails");
+        let thumbnails_dir = crate::setup::app_data_dir(&app).unwrap().join("thumbnails");
         std::fs::create_dir_all(&thumbnails_dir).unwrap();
 
         let thumbnail_filename = format!("thumbnail_{}.jpg", hash);

--- a/src-tauri/src/settings/provider.rs
+++ b/src-tauri/src/settings/provider.rs
@@ -53,7 +53,7 @@ impl SettingsFileProvider {
     ///
     /// Returns an `Err` if the app data directory cannot be resolved or created.
     pub fn new(app: &AppHandle, filename: &str) -> Result<Self> {
-        let dir = app.path().app_data_dir()?;
+        let dir = crate::setup::app_data_dir(app)?;
         fs::create_dir_all(&dir)?;
         let home_dir = app
             .path()

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -5,8 +5,8 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     SqlitePool,
 };
-use std::{fs, str::FromStr, sync::Arc};
-use tauri::{App, Manager, Theme};
+use std::{fs, path::PathBuf, str::FromStr, sync::Arc};
+use tauri::{App, Manager, Runtime, Theme};
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind};
 use tokio::sync::RwLock;
 
@@ -25,6 +25,38 @@ use crate::{
     },
     state::app_state::AppState,
 };
+
+/// Reads a non-empty `ROOKREADER_DATA_DIR` override into a path, if present.
+#[cfg(any(debug_assertions, feature = "e2e-test"))]
+fn data_dir_from_env(var: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    var.filter(|v| !v.is_empty()).map(PathBuf::from)
+}
+
+/// Resolves the base directory for app data (DB, settings, thumbnails).
+///
+/// In debug builds and in the `e2e-test` E2E build, a non-empty `ROOKREADER_DATA_DIR`
+/// environment variable overrides Tauri's `app_data_dir()`, so E2E tests run against an
+/// isolated, ephemeral directory instead of the real user profile. Shipped/production builds
+/// (release without the feature) always use `app_data_dir()`.
+///
+/// # Arguments
+///
+/// * `manager` - Any Tauri manager (`App` or `AppHandle`) able to resolve paths.
+///
+/// # Returns
+///
+/// The base directory that holds the app's data files.
+///
+/// # Errors
+///
+/// Returns an `Err` if the app data directory cannot be resolved.
+pub(crate) fn app_data_dir<R: Runtime, M: Manager<R>>(manager: &M) -> error::Result<PathBuf> {
+    #[cfg(any(debug_assertions, feature = "e2e-test"))]
+    if let Some(dir) = data_dir_from_env(std::env::var_os("ROOKREADER_DATA_DIR")) {
+        return Ok(dir);
+    }
+    Ok(manager.path().app_data_dir()?)
+}
 
 /// Returns the settings store filename for the current build profile.
 pub fn settings_filename() -> &'static str {
@@ -60,6 +92,20 @@ pub fn setup(app: &App) -> error::Result<()> {
         .and_then(|value| serde_json::from_value(value).ok())
         .unwrap_or_default();
     setup_logger(app, &log_settings)?;
+
+    // E2E only: register the WDIO plugins AFTER our logger has claimed the global `log`
+    // logger, so tauri-plugin-wdio's own `set_boxed_logger` fails gracefully instead of
+    // blocking ours. Then grant the WDIO ACL permission (the plugins must be registered
+    // first for the permission to resolve). Gated by the `e2e-test` feature and the
+    // `TAURI_WEBDRIVER_PORT` the service sets when it launches the app; absent from
+    // shipped/production builds.
+    #[cfg(feature = "e2e-test")]
+    if std::env::var_os("TAURI_WEBDRIVER_PORT").is_some() {
+        let handle = app.handle();
+        handle.plugin(tauri_plugin_wdio::init())?;
+        handle.plugin(tauri_plugin_wdio_webdriver::init())?;
+        handle.add_capability(include_str!("../runtime-capabilities/wdio-webdriver.json"))?;
+    }
 
     let settings = AppSettings::load_and_persist_normalized(&provider)?;
 
@@ -211,7 +257,7 @@ fn set_theme(app: &App, app_theme: &AppTheme) {
 
 /// Helper function to initialize the database for the application.
 fn setup_database(app: &App) -> error::Result<()> {
-    let app_data_dir_path = app.path().app_data_dir()?;
+    let app_data_dir_path = app_data_dir(app)?;
     fs::create_dir_all(&app_data_dir_path)?;
 
     let db_filename = if cfg!(debug_assertions) {
@@ -280,5 +326,21 @@ mod tests {
             ResizeFilter::Lanczos3
         );
         assert_eq!(container_settings.image_cache_size_mib, 2048);
+    }
+
+    #[cfg(any(debug_assertions, feature = "e2e-test"))]
+    #[test]
+    fn env_override_used_when_non_empty() {
+        assert_eq!(
+            data_dir_from_env(Some(std::ffi::OsString::from("/tmp/rr-e2e"))),
+            Some(PathBuf::from("/tmp/rr-e2e"))
+        );
+    }
+
+    #[cfg(any(debug_assertions, feature = "e2e-test"))]
+    #[test]
+    fn env_override_ignored_when_absent_or_empty() {
+        assert_eq!(data_dir_from_env(None), None);
+        assert_eq!(data_dir_from_env(Some(std::ffi::OsString::new())), None);
     }
 }

--- a/src-tauri/tauri.conf.e2e.json
+++ b/src-tauri/tauri.conf.e2e.json
@@ -1,0 +1,5 @@
+{
+  "app": {
+    "withGlobalTauri": true
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,6 +26,13 @@ if (!rootElement) {
 
 const initializeAndRender = async () => {
   try {
+    // Load the WDIO frontend bridge only in E2E builds. `VITE_E2E` is set by
+    // `wdio.conf.ts` onPrepare; in normal builds this branch is tree-shaken away,
+    // so `@wdio/tauri-plugin` never ships to production.
+    if (import.meta.env.VITE_E2E === "true") {
+      await import("@wdio/tauri-plugin");
+    }
+
     const settings = await loadAllSettings();
 
     const preloadedState = {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Set to "true" for E2E builds to load the `@wdio/tauri-plugin` frontend bridge. */
+  readonly VITE_E2E?: string;
+}

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,41 +1,70 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+/** Best-effort removal of a directory, tolerating Windows file locks and missing paths. */
+function removeDir(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 300 });
+  } catch {
+    // ignore — a leftover temp dir is harmless and the OS reclaims it later
+  }
+}
 
 const isWindows = os.platform() === "win32";
 const binaryExt = isWindows ? ".exe" : "";
 
-let tauriDriver: ReturnType<typeof spawn>;
-let exit = false;
+// A fresh, empty data directory per run isolates the app's config/DB/thumbnails from any
+// pre-existing user data. The e2e-test build honours ROOKREADER_DATA_DIR. Created only in the
+// launcher process (which spawns the shared app instance); spec workers re-load this config
+// too, so guarding on WDIO_WORKER_ID avoids leaking an unused empty dir per worker.
+const dataDir = process.env.WDIO_WORKER_ID
+  ? ""
+  : mkdtempSync(path.join(os.tmpdir(), "rookreader-e2e-"));
+
+// E2E runs the RELEASE binary built with the `e2e-test` feature (which compiles in the
+// embedded WebDriver plugin). Testing the optimized binary matches pre-migration behaviour.
+const appBinary = path.join(
+  process.cwd(),
+  "src-tauri",
+  "target",
+  "release",
+  `rook-reader${binaryExt}`,
+);
 
 export const config = {
   runner: "local",
   tsConfigPath: "tsconfig.json",
-  host: "127.0.0.1",
-  port: 4444,
   specs: ["e2e/specs/**/*.ts"],
+  maxInstances: 1,
+  capabilities: [
+    {
+      browserName: "tauri",
+      "wdio:enforceWebDriverClassic": true,
+      "tauri:options": {
+        application: appBinary,
+      },
+      "wdio:tauriServiceOptions": {
+        appBinaryPath: appBinary,
+        env: {
+          ROOKREADER_DATA_DIR: dataDir,
+        },
+      },
+    },
+  ],
   services: [
     [
       "@wdio/tauri-service",
       {
-        autoInstallTauriDriver: true,
+        driverProvider: "embedded",
+        appBinaryPath: appBinary,
+        // The embedded WebDriver server takes longer to come up (especially on
+        // Windows); give it headroom and avoid false "unreachable — restarting".
+        startTimeout: 60000,
+        statusPollTimeout: 8000,
       },
     ],
-  ],
-  maxInstances: 1,
-  capabilities: [
-    {
-      maxInstances: 1,
-      "tauri:options": {
-        application: path.join(
-          process.cwd(),
-          "src-tauri",
-          "target",
-          "release",
-          `rook-reader${binaryExt}`,
-        ),
-      },
-    },
   ],
   reporters: ["spec"],
   framework: "mocha",
@@ -45,63 +74,47 @@ export const config = {
     timeout: 60000,
   },
 
-  // ensure the rust project is built since we expect this binary to exist for the webdriver sessions
+  // Build the RELEASE binary WITH the e2e-test feature (compiles in the WDIO plugins),
+  // VITE_E2E=true (loads the @wdio/tauri-plugin frontend bridge into the webview), and the
+  // E2E config overlay that enables withGlobalTauri (needed by the frontend bridge for
+  // window-state/focus). The overlay is applied only here, so production keeps it disabled.
   onPrepare: () => {
-    spawnSync("npm", ["run", "tauri", "build", "--", "--no-bundle"], {
-      cwd: process.cwd(),
-      stdio: "inherit",
-      shell: true,
-    });
-  },
-
-  // ensure we are running `tauri-driver` before the session starts so that we can proxy the webdriver requests
-  beforeSession: () => {
-    const args = isWindows ? ["--native-driver", path.join(process.cwd(), "msedgedriver.exe")] : [];
-    tauriDriver = spawn(path.resolve(os.homedir(), ".cargo", "bin", "tauri-driver"), args, {
-      stdio: [null, process.stdout, process.stderr],
-    });
-
-    tauriDriver.on("error", (error) => {
-      console.error("tauri-driver error:", error);
-      process.exit(1);
-    });
-    tauriDriver.on("exit", (code) => {
-      if (!exit) {
-        console.error("tauri-driver exited with code:", code);
-        process.exit(1);
+    // Self-healing cleanup: remove any leftover data dirs from previous runs whose
+    // onComplete could not delete them (the app briefly holds the SQLite file on exit).
+    const tmp = os.tmpdir();
+    for (const entry of readdirSync(tmp)) {
+      if (entry.startsWith("rookreader-e2e-") && path.join(tmp, entry) !== dataDir) {
+        removeDir(path.join(tmp, entry));
       }
-    });
+    }
+
+    const e2eConfig = path.join(process.cwd(), "src-tauri", "tauri.conf.e2e.json");
+    spawnSync(
+      "npm",
+      [
+        "run",
+        "tauri",
+        "build",
+        "--",
+        "--no-bundle",
+        "--features",
+        "e2e-test",
+        "--config",
+        e2eConfig,
+      ],
+      {
+        cwd: process.cwd(),
+        stdio: "inherit",
+        shell: true,
+        env: { ...process.env, VITE_E2E: "true" },
+      },
+    );
   },
 
-  // clean up the `tauri-driver` process we spawned at the start of the session
-  // note that afterSession might not run if the session fails to start, so we also run the cleanup on shutdown
-  afterSession: () => {
-    closeTauriDriver();
+  // Remove the ephemeral data directory once the run completes. Any dir that can't be
+  // deleted in time (Windows may hold the SQLite file briefly after shutdown) is swept by
+  // the next run's onPrepare.
+  onComplete: () => {
+    if (dataDir) removeDir(dataDir);
   },
 };
-
-function closeTauriDriver() {
-  exit = true;
-  tauriDriver?.kill();
-}
-
-function onShutdown(fn: () => void) {
-  const cleanup = () => {
-    try {
-      fn();
-    } finally {
-      process.exit();
-    }
-  };
-
-  process.on("exit", cleanup);
-  process.on("SIGINT", cleanup);
-  process.on("SIGTERM", cleanup);
-  process.on("SIGHUP", cleanup);
-  process.on("SIGBREAK", cleanup);
-}
-
-// ensure tauri-driver is closed when our test process exits
-onShutdown(() => {
-  closeTauriDriver();
-});


### PR DESCRIPTION
## Description

- **Backend** (new `e2e-test` Cargo feature, absent from production): add the embedded WDIO
  plugins, register them after the logger to avoid a conflict, grant their permission via a
  runtime capability, and add a `ROOKREADER_DATA_DIR` override for isolation.
- **Harness**: `wdio.conf.ts` → embedded provider building the release binary with
  `--features e2e-test`; load the frontend bridge and `withGlobalTauri` only for E2E; bump
  `@wdio/tauri-service` to 1.2.0 (+ `@wdio/native-utils` override for an upstream bug).
- **Specs**: isolate the provider's unsupported inputs (right-click, arrow keys) in
  `e2e/input.ts`; submit the path form directly; close the settings window between specs.
- **CI**: drop `webkit2gtk-driver`, add `xvfb`, run one `npm run test:e2e` on all platforms.

## Related Issue

None.

## Type of Change
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] Refactoring (code changes that neither fix a bug nor add a feature)
* [ ] Dependency update (updates to dependencies or packages)
* [ ] Documentation update
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in English, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings (e.g., passed `cargo clippy` for Rust, Biome check for frontend).
* [x] I have tested that the app builds successfully across target platforms.

## Screenshots (if appropriate):

None.
